### PR TITLE
Added getImage and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,15 +70,28 @@ After this you can use all the available methods
 | toggleShuffle | Toggle shuffle options    |     |
 | toggleShuffle | Toggle Repeat options    |     |
 | getPlaybackPosition | Get's the current tracks playback position       |    |
-
-
-
+| getImage | Gets a Uint8List encoded image(memoryImage)       |  imageUri  |
+| imageLinkToURi | Takes an image url and returns image uri(for get image)    |  imageLink  |
 
 ## Example
 
 Demonstrates how to use the spotify_playback plugin.
 
 See the [example documentation](example/README.md) for more information.
+
+## GetImage   
+```dart
+//You can provide an image uri
+SpotifyPlayback.getImage("spotify:image:3269971d34d3f17f16efc2dfa95e302cc961a36c");
+
+//Or you can provide an url returned webAPI
+SpotifyPlayback.getImage(SpotifyPlayback.imageLinkToURi("https://i.scdn.co/image/3269971d34d3f17f16efc2dfa95e302cc961a36c"));
+
+//Theese both return a Uint8List encoded image.
+//You can then use the Image.memory() to display the image
+Image.memory(yourUint8ListImageHere)
+
+```
 
 ## Changelog
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'dart:async';
@@ -13,6 +14,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   bool _connectedToSpotify = false;
+  Uint8List image = null;
 
   @override
   void initState() {
@@ -214,6 +216,21 @@ class _MyAppState extends State<MyApp> {
     }
   }
 
+    /// Get the image by provided uri
+  Future<void> getImage(String uri) async {
+    try {
+      await SpotifyPlayback.getImage(uri).then((imageReceived) {
+        setState(() {
+          image = imageReceived;
+        });
+      }, onError: (error) {
+        print(error);
+      });
+    } on PlatformException {
+      print('Failed to play.');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -278,7 +295,12 @@ class _MyAppState extends State<MyApp> {
                   RaisedButton(
                     onPressed: () => seekToRelativePosition(),
                     child: Text("Seek Relative(+5s)"),
-                  )
+                  ),
+                  RaisedButton(
+                    onPressed: () => getImage(SpotifyPlayback.imageLinkToURi("https://i.scdn.co/image/3269971d34d3f17f16efc2dfa95e302cc961a36c")),
+                    child: Text("Get image")),
+              
+                  (image != null) ? Image.memory(image,height: 100,) : Text("Image Placeholder")
                 ],
               ),
             ]),

--- a/lib/spotify_playback.dart
+++ b/lib/spotify_playback.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-
+import 'dart:typed_data';
 import 'package:flutter/services.dart';
 
 class SpotifyPlayback {
@@ -107,4 +107,15 @@ class SpotifyPlayback {
         await _channel.invokeMethod("seekToRelativePosition", {"relativeTime": relativeTime.toString()});
     return success;
   }
+  /// This method is used to get an image by the provided imageURI and returns a Uint8List(MemoryImage)
+  static Future<Uint8List> getImage(String uri) async {
+    final Uint8List success = await _channel.invokeMethod("getImage", {"uri": uri});
+    return success;
+  }
+
+  /// This method is used to convert image urls provided by web api to spotify image URIs 
+  static String imageLinkToURi(String imageLink) {
+  return "spotify:image:"+imageLink.replaceRange(0, imageLink.lastIndexOf("/")+1, "");
+}
+
 }


### PR DESCRIPTION
I added a function to get the image from the API - It returns a Uint8List which can be used by Image.memory(), MemoryImage() in Flutter. You can provide it with a Spotify image uri "spotify:image:theImageUri" or you can use the imageLinkToURi method to convert an image link provided by the Web api to a spotify uri.